### PR TITLE
accumulo: init at 1.7.3, 1.8.1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -171,6 +171,7 @@
   ./services/continuous-integration/jenkins/default.nix
   ./services/continuous-integration/jenkins/job-builder.nix
   ./services/continuous-integration/jenkins/slave.nix
+  ./services/databases/accumulo.nix
   ./services/databases/4store-endpoint.nix
   ./services/databases/4store.nix
   ./services/databases/clickhouse.nix

--- a/nixos/modules/services/databases/accumulo.nix
+++ b/nixos/modules/services/databases/accumulo.nix
@@ -230,8 +230,7 @@ in {
         } // cfg.env;
         serviceConfig = {
           ExecStart = "${cfg.package}/bin/accumulo tserver" + (optionalString (cfg.listenAddress!=null) " -a ${cfg.listenAddress}");
-          Restart = "always";
-          RestartSec = "5";
+          Restart = "no";  # start again manually; automatic restart is not desirable if it crashed (it may need more memory) or if it stopped gracefully
           User = "accumulo";
           Group = "accumulo";
         };

--- a/nixos/modules/services/databases/accumulo.nix
+++ b/nixos/modules/services/databases/accumulo.nix
@@ -1,0 +1,203 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.accumulo;
+
+  configurationToXml = attrs:
+    let
+      xmlescape = builtins.replaceStrings ["&" "<" ">"] ["&amp;" "&lt;" "&gt;"];
+    in ''
+      <configuration>
+      ${concatStrings (mapAttrsToList (name: value: ''
+        <property>
+          <name>${xmlescape name}</name>
+          <value>${xmlescape value}</value>
+        </property>
+       '') attrs)}
+      </configuration>
+    '';
+
+  configDir = pkgs.buildEnv {
+    name = "accumulo-conf-dir";
+    paths = [
+      (pkgs.writeTextDir "accumulo-env.sh"            "") # unused while we set the env by makeWrapper but must exist
+      (pkgs.writeTextDir "accumulo-site.xml"          (configurationToXml cfg.accumuloSite))
+      (pkgs.writeTextDir "core-site.xml"              (configurationToXml cfg.coreSite))
+      (pkgs.writeTextDir "hdfs-site.xml"              (configurationToXml cfg.hdfsSite))
+      (pkgs.writeTextDir "generic_logger.properties"  cfg.logging)
+      (pkgs.writeTextDir "log4j.properties"           cfg.logging)
+    ];
+  };
+
+  accumulo-configured = pkgs.stdenv.mkDerivation {
+    name = "${cfg.package.name}-configured";
+    buildInputs = [ pkgs.makeWrapper ];
+    buildCommand = ''
+      mkdir -p $out/bin
+      for n in ${cfg.package}/bin/*; do
+        [[ $n = *config* ]] || makeWrapper $n $out/bin/$(basename $n) \
+          --prefix LD_LIBRARY_PATH : "${with pkgs; stdenv.lib.makeLibraryPath [ openssl snappy zlib bzip2 ] /* libhadoop.so loads them by dlopen() */ }" \
+          --set ZOOKEEPER_HOME     "${pkgs.zookeeper}" \
+          --set HADOOP_PREFIX      "${cfg.hadoop-package}" \
+          --set HADOOP_CONF_DIR    "${configDir}" \
+          --set ACCUMULO_CONF_DIR  "${configDir}" \
+          ${ concatStrings (mapAttrsToList (k: v: " --set '${k}' '${v}'") cfg.env) }
+      done
+    '';
+  };
+
+in {
+
+  options.services.accumulo = {
+    enable        = mkEnableOption "configured accumulo";
+    enableMaster  = mkEnableOption "master daemon";
+    enableTserver = mkEnableOption "tablet server daemon";
+    enableGc      = mkEnableOption "garbage collect daemon";
+    enableMonitor = mkEnableOption "monitor daemon";
+
+    package = mkOption {
+      description = "The accumulo package to use";
+      type = types.package;
+      default = pkgs.accumulo;
+    };
+
+    hadoop-package = mkOption {
+      description = "The hadoop package to use";
+      type = types.package;
+      default = pkgs.hadoop;
+    };
+
+    coreSite = mkOption {
+      description = "HDFS client settings (core-site.xml)";
+      type = types.attrsOf types.str;
+      default = {
+        "fs.defaultFS"      = "hdfs://127.0.0.1:8020";
+      };
+    };
+
+    hdfsSite = mkOption {
+      description = "HDFS client settings (hdfs-site.xml)";
+      type = types.attrsOf types.str;
+      default = {};
+    };
+
+    accumuloSite = mkOption {
+      description = "Accumulo settings (accumulo-site.xml)";
+      type = types.attrsOf types.str;
+      default = {
+        "instance.zookeeper.host"            = "127.0.0.1"; # comma-separated list of zookeeper servers
+        "instance.dfs.dir"                   = "/accumulo"; # path on HDFS (address is in coreSite."fs.defaultFS")
+        "tserver.memory.maps.native.enabled" = "true";
+        "tserver.wal.sync.method"            = "hflush";
+      };
+    };
+
+    logging = mkOption {
+      description = "log4j properties";
+      type = types.lines;
+      default = ''
+        log4j.rootLogger=INFO,CONSOLE
+        log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+        log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+        log4j.appender.CONSOLE.layout.ConversionPattern=[myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n
+      '';
+    };
+
+    env = mkOption {
+      description = "settings in envirinment vars, mainly per-daemon command line options";
+      type = types.attrsOf types.str;
+      default = {
+        ACCUMULO_GENERAL_OPTS = "-XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -Djava.net.preferIPv4Stack=true -XX:+CMSClassUnloadingEnabled";
+        ACCUMULO_TSERVER_OPTS = "-Xmx128m -Xms128m";
+        ACCUMULO_MASTER_OPTS  = "-Xmx128m -Xms128m";
+        ACCUMULO_MONITOR_OPTS = "-Xmx64m -Xms64m";
+        ACCUMULO_GC_OPTS      = "-Xmx64m -Xms64m";
+        ACCUMULO_SHELL_OPTS   = "-Xmx128m -Xms64m";
+        ACCUMULO_OTHER_OPTS   = "-Xmx128m -Xms64m";
+       #ACCUMULO_LOG_DIR      = "/var/log/accumulo";
+      };
+    };
+  };
+
+
+  config = mkMerge [
+    (mkIf cfg.enable {
+      # Accumulo CLI utilities with the config on $PATH
+      environment.systemPackages = [ accumulo-configured ];
+    })
+
+    (mkIf (cfg.enableMaster || cfg.enableTserver || cfg.enableGc || cfg.enableMonitor) {
+      services.accumulo.enable = true;
+      users.extraUsers.accumulo = {
+        name = "accumulo";
+        group = "accumulo";
+        uid = config.ids.uids.accumulo;
+        description = "Accumulo server user";
+      };
+      users.extraGroups.accumulo.gid = config.ids.gids.accumulo;
+    })
+
+    (mkIf cfg.enableMaster {
+      systemd.services.accumulo-master = {
+        description = "Accumulo master";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+        serviceConfig = {
+          ExecStart = "${accumulo-configured}/bin/accumulo master";
+          Restart = "always";
+          RestartSec = "5";
+          User = "accumulo";
+          Group = "accumulo";
+        };
+      };
+    })
+
+    (mkIf cfg.enableTserver {
+      systemd.services.accumulo-tserver = {
+        description = "Accumulo tablet server";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+        serviceConfig = {
+          ExecStart = "${accumulo-configured}/bin/accumulo tserver";
+          Restart = "always";
+          RestartSec = "5";
+          User = "accumulo";
+          Group = "accumulo";
+        };
+      };
+    })
+
+    (mkIf cfg.enableGc {
+      systemd.services.accumulo-gc = {
+        description = "Accumulo garbage collector";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+        serviceConfig = {
+          ExecStart = "${accumulo-configured}/bin/accumulo monitor";
+          Restart = "always";
+          RestartSec = "5";
+          User = "accumulo";
+          Group = "accumulo";
+        };
+      };
+    })
+
+    (mkIf cfg.enableMonitor {
+      systemd.services.accumulo-monitor = {
+        description = "Accumulo monitor";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+        serviceConfig = {
+          ExecStart = "${accumulo-configured}/bin/accumulo monitor";
+          Restart = "always";
+          RestartSec = "5";
+          User = "accumulo";
+          Group = "accumulo";
+        };
+      };
+    })
+  ];
+
+}

--- a/nixos/modules/services/databases/accumulo.nix
+++ b/nixos/modules/services/databases/accumulo.nix
@@ -133,10 +133,9 @@ in {
       users.extraUsers.accumulo = {
         name = "accumulo";
         group = "accumulo";
-        uid = config.ids.uids.accumulo;
         description = "Accumulo server user";
       };
-      users.extraGroups.accumulo.gid = config.ids.gids.accumulo;
+      users.extraGroups.accumulo = {};
     })
 
     (mkIf cfg.enableMaster {

--- a/pkgs/servers/nosql/accumulo/default.nix
+++ b/pkgs/servers/nosql/accumulo/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchurl, makeWrapper, jdk, which, jre, bash, coreutils, numactl }:
+
+let
+  common = { version, sha256 }:
+    stdenv.mkDerivation {
+      name = "accumulo-${version}";
+
+      src = fetchurl {
+        url = "mirror://apache/accumulo/${version}/accumulo-${version}-bin.tar.gz";
+        inherit sha256;
+      };
+
+      nativeBuildInputs = [ makeWrapper jdk ];
+
+      buildPhase = "bin/build_native_library.sh";
+
+      installPhase = ''
+        mkdir -p $out
+        cp -dpR * $out/
+
+        for n in $out/bin/*; do
+          # do not wrap config.sh and config-server.sh
+          [[ $n = *config* ]] || wrapProgram $n \
+            --prefix PATH : "${stdenv.lib.makeBinPath [ which jre bash coreutils numactl ]}" \
+            --set JAVA_HOME "${jre}" \
+            --set ACCUMULO_HOME "$out"
+        done
+      '';
+
+      meta = with stdenv.lib; {
+        homepage = http://accumulo.apache.org/;
+        description = "Key/value store based on the design of Google's BigTable";
+        license = licenses.asl20;
+        maintainers = with maintainers; [ volth ];
+        platforms = [ "x86_64-linux" ];
+      };
+    };
+in {
+  accumulo_1_7 = common {
+    version = "1.7.3";
+    sha256 = "1nl0jjy8c75b0dgawdgv0kw5s92wrskdbv0cx1l4n5mw7wgjykr9";
+  };
+  accumulo_1_8 = common {
+    version = "1.8.1";
+    sha256 = "1x1pya8r3g8b4rz9qsb12cwbjs2ar1cvvhm73s8afp4k4glbz8zb";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6020,6 +6020,11 @@ with pkgs;
     hadoop_2_8;
   hadoop = hadoop_2_7;
 
+  inherit (callPackage ../servers/nosql/accumulo { })
+    accumulo_1_7
+    accumulo_1_8;
+  accumulo = accumulo_1_7;
+
   io = callPackage ../development/interpreters/io { };
 
   j = callPackage ../development/interpreters/j {};


### PR DESCRIPTION
###### Motivation for this change

Key/value store based on the design of Google's BigTable.
Made by NSA.

Depends on Hadoop update PR: https://github.com/NixOS/nixpkgs/pull/25914

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I use ```1.7``` branch in production for more than a year on Ubuntu, this PR have been tested using a clone of production system as a part of migration to NixOS

---

